### PR TITLE
Release v0.2.1 | Better organised config annotations, decoupling from JPARepositoy, Javax etc.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,7 +2,7 @@
 
 ## [0.2.1] - 10th December 2023
 
-- BREAKING: Better Organise DataSourceConfig to segregate Primary and Secondary data sources as per Spring
+- BREAKING CHANGE: Better Organise DataSourceConfig to segregate Primary and Secondary data sources as per Spring
   Convention.
 - Allow `@TargetSecondaryDataSource` to be placed on any Repository, not just JpaRepository.
 - Adaptive `EntityManagerFactory` for `TransactionManager` will be generated based on

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,8 +2,52 @@
 
 ## [0.2.1] - 10th December 2023
 
-- BREAKING CHANGE: Better Organise DataSourceConfig to segregate Primary and Secondary data sources as per Spring
-  Convention.
+- BREAKING CHANGE: Better Organise DataSourceConfig to segregate Primary and Secondary data sources
+  as per Spring Convention. Also renamed `@TargetDataSource` to `@TargetSecondaryDataSource` to\
+  avoid confusion.
+
+  Before:
+
+  ```java
+  @Configuration
+  @EnableMultiDataSourceConfig(
+    repositoryPackages = {
+      "com.sample"
+    },
+    exactEntityPackages = {
+      "com.sample.project.sample_service.entities.mysql"
+    },
+    dataSourceConfigs = {
+        @DataSourceConfig(dataSourceName = "master", isPrimary = true),
+        @DataSourceConfig(dataSourceName = "replica-2"),
+        @DataSourceConfig(dataSourceName = "read-replica")
+    }
+  )
+  public class ServiceConfig {
+  }
+  ```
+
+  After:
+
+  ```java
+   @Configuration
+   @EnableMultiDataSourceConfig(
+      repositoryPackages = {
+        "com.sample"
+      },
+      exactEntityPackages = {
+        "com.sample.project.sample_service.entities.mysql"
+      },
+      primaryDataSourceConfig = @DataSourceConfig(dataSourceName = "master"),
+      secondaryDataSourceConfigs = {
+          @DataSourceConfig(dataSourceName = "replica-2"),
+          @DataSourceConfig(dataSourceName = "read-replica")
+      }
+   )
+   public class ServiceConfig {
+   }
+  ```
+
 - Allow `@TargetSecondaryDataSource` to be placed on any Repository, not just JpaRepository.
 - Adaptive `EntityManagerFactory` for `TransactionManager` will be generated based on
   `LocalContainerEntityManagerFactoryBean`. Decoupled from Javax/Jakarta implementations.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,13 @@
 # Releases
 
+## [0.2.1] - 10th December 2023
+
+- BREAKING: Better Organise DataSourceConfig to segregate Primary and Secondary data sources as per Spring
+  Convention.
+- Allow `@TargetSecondaryDataSource` to be placed on any Repository, not just JpaRepository.
+- Adaptive `EntityManagerFactory` for `TransactionManager` will be generated based on
+  `LocalContainerEntityManagerFactoryBean`. Decoupled from Javax/Jakarta implementations.
+
 ## [0.1.2] - 6th October 2023
 
 - HOTFIX: Fix `@EnableJpaRepositories.basePackages` being empty for secondary data sources

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -49,6 +49,7 @@
   ```
 
 - Allow `@TargetSecondaryDataSource` to be placed on any Repository, not just JpaRepository.
+
 - Adaptive `EntityManagerFactory` for `TransactionManager` will be generated based on
   `LocalContainerEntityManagerFactoryBean`. Decoupled from Javax/Jakarta implementations.
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,8 +2,8 @@
 
 ## [0.2.1] - 10th December 2023
 
-- BREAKING CHANGE: Better Organise DataSourceConfig to segregate Primary and Secondary data sources
-  as per Spring Convention. Also renamed `@TargetDataSource` to `@TargetSecondaryDataSource` to\
+- BREAKING CHANGE: Better organised DataSourceConfig to segregate Primary and Secondary data sources
+  as per Spring Convention. Also renamed `@TargetDataSource` to `@TargetSecondaryDataSource` to
   avoid confusion.
 
   Before:
@@ -52,6 +52,10 @@
 
 - Adaptive `EntityManagerFactory` for `TransactionManager` will be generated based on
   `LocalContainerEntityManagerFactoryBean`. Decoupled from Javax/Jakarta implementations.
+
+- Allow possibility for overriding different JPA properties for each data source by adding
+  `@DataSourceConfig.overridingJpaPropertiesPath` field. By default, it will take the default
+  `spring.jpa.properties` path.
 
 ## [0.1.2] - 6th October 2023
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ for configuring multi-data source configurations for a service. Let's break down
       the primary data source and its configuration. The primary data source will be able
       to access every repository other than the repositories generated for the secondary data
       sources.
-    - `dataSourceConfigs`: An array of `@DataSourceConfig` annotations. Each annotation represents
-      a data source and its configuration.
+    - `secondaryDataSourceConfigs`: An array of `@DataSourceConfig` annotations. Each annotation
+      represents a data source and its configuration. The secondary data sources will only be able
+      to access the repositories generated for them.
 
 #### @EnableMultiDataSourceConfig.DataSourceConfig
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ for configuring multi-data source configurations for a service. Let's break down
       naming format. If this is not specified, the generated repositories will be placed in the
       same package as the class where this annotation is applied, followed by
       `.generated.repositories` and then `.<data_source_name>`.
+    - `primaryDataSourceConfig`: A `@DataSourceConfig` annotation. This annotation represents
+      the primary data source and its configuration.
     - `dataSourceConfigs`: An array of `@DataSourceConfig` annotations. Each annotation represents
       a data source and its configuration.
 
@@ -99,15 +101,12 @@ for configuring multi-data source configurations for a service. Let's break down
     - `dataSourceName`: The name of the data source. It is used to generate the date source
       beans and to name the generated classes, packages, and property paths for the data
       source properties.
-    - `isPrimary`: Whether the data source is the primary data source. If this is set to
-      `true`, the generated beans for this data source will be annotated with `@Primary`. Hence
-      this should be set to `true` for only one data source.
-    - `dataSourceClassPropertiesPath`: The path of the data source class properties in the
+    - `dataSourceClassPropertiesPath`: The key/path of the data source class properties in the
       application properties. Eg. `spring.datasource.hikari` for Hikari data sources.
-    - `hibernateBeanContainerPropertyPath`: The path of the Hibernate bean container property in
-      the application properties. This is needed to manually set the hibernate bean container to
-      the spring bean container to ensure that the hibernate beans like attribute converters are
-      managed by spring.
+    - `overridingPropertiesPath`:  The key/path under which the JPA properties to override for this
+      data source are located in the application properties file. This allows overriding of the JPA
+      properties for each data source. By default, it will take the default `spring.jpa.properties`
+      path.
 
 ### @TargetSecondaryDataSource
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ down to this library in the future.
   * [Annotations Provided](#annotations-provided)
     * [@EnableMultiDataSourceConfig](#enablemultidatasourceconfig)
       * [@EnableMultiDataSourceConfig.DataSourceConfig](#enablemultidatasourceconfigdatasourceconfig)
-    * [@TargetDataSource](#targetdatasource)
+    * [@TargetSecondaryDataSource](#targetsecondarydatasource)
   * [Usage](#usage)
   * [Building from Source (Maven)](#building-from-source-maven)
   * [Removing Dependency on spring-multi-data-source without Losing Functionality](#removing-dependency-on-spring-multi-data-source-without-losing-functionality)
@@ -109,7 +109,7 @@ for configuring multi-data source configurations for a service. Let's break down
       the spring bean container to ensure that the hibernate beans like attribute converters are
       managed by spring.
 
-### @TargetDataSource
+### @TargetSecondaryDataSource
 
 - This annotation is used to create copies of repositories in relevant packages and
   autoconfigure them to use the relevant data sources.
@@ -150,8 +150,8 @@ intended to be used for generating code for configuring data sources during the 
       exactEntityPackages = {
         "com.sample.project.sample_service.entities.mysql"
       },
-      dataSourceConfigs = {
-          @DataSourceConfig(dataSourceName = "master", isPrimary = true),
+      primaryDataSourceConfig = @DataSourceConfig(dataSourceName = "master"),
+      secondaryDataSourceConfigs = {
           @DataSourceConfig(dataSourceName = "replica-2"),
           @DataSourceConfig(dataSourceName = "read-replica")
       }
@@ -160,20 +160,20 @@ intended to be used for generating code for configuring data sources during the 
    }
    ```
 
-3. Add the `@TargetDataSource` annotation to the repository methods that need to be
+3. Add the `@TargetSecondaryDataSource` annotation to the repository methods that need to be
    configured for a specific data source, and specify the data source name.
 
     ```java
     @Repository
     public interface ServiceRepository extends JpaRepository<ServiceEntity, Long> {
     
-       @TargetDataSource("read-replica")
+       @TargetSecondaryDataSource("read-replica")
        ServiceEntity findByCustomIdAndDate(String id, Date date);
     
        // To override the default JpaRepository methods in the generated repository
        // All base methods that have not been overridden along with this annotation will throw an 
        // UnsupportedOperationException.
-       @TargetDataSource("read-replica")
+       @TargetSecondaryDataSource("read-replica")
        @Override
        ServiceEntity getById(Long id);
     }
@@ -250,7 +250,7 @@ longer wish to be tied down to this library.
    project from the `target/generated-sources/annotations` directory.
 2. Remove `implements IMultiDataSourceConfig` from the generated `@Configuration` classes.
 3. Remove the `@EnableMultiDataSourceConfig` annotation from your configuration class.
-4. Remove the `@TargetDataSource` annotation from your repository methods.
+4. Remove the `@TargetSecondaryDataSource` annotation from your repository methods.
 5. Remove the `spring-multi-data-source` dependency from your project pom.
 
 And that's all you have to do! You are no longer tied down to this library and have the freedom to

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ for configuring multi-data source configurations for a service. Let's break down
     - `dataSourceName`: The name of the data source. It is used to generate the date source
       beans and to name the generated classes, packages, and property paths for the data
       source properties.
-    - `dataSourceClassPropertiesPath`: The key/path of the data source class properties in the
-      application properties. Eg. `spring.datasource.hikari` for Hikari data sources.
-    - `overridingPropertiesPath`:  The key/path under which the JPA properties to override for this
-      data source are located in the application properties file. This allows overriding of the JPA
+    - `dataSourceClassPropertiesPath`:The application properties key/path of the data source class'
+      properties. Eg. `spring.datasource.hikari` for Hikari data sources.
+    - `overridingPropertiesPath`:  The application properties key/path under which the JPA
+      properties to override for this data source are located. This allows overriding of the JPA
       properties for each data source. By default, it will take the default `spring.jpa.properties`
       path.
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,12 +164,6 @@
     </dependency>
 
     <dependency>
-      <artifactId>javax.persistence-api</artifactId>
-      <groupId>javax.persistence</groupId>
-      <version>2.2</version>
-    </dependency>
-
-    <dependency>
       <artifactId>junit-jupiter</artifactId>
       <groupId>org.junit.jupiter</groupId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -233,5 +233,5 @@
   </scm>
 
   <url>http://www.github.com/dhi13man/spring-multi-data-source</url>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.1</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -233,5 +233,5 @@
   </scm>
 
   <url>http://www.github.com/dhi13man/spring-multi-data-source</url>
-  <version>0.1.2</version>
+  <version>0.2.1-SNAPSHOT</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
       </exclusions>
       <groupId>org.springframework.data</groupId>
       <scope>provided</scope>
-      <version>2.6.10</version>
+      <version>${spring.boot.version}</version>
     </dependency>
 
     <dependency>
@@ -223,7 +223,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <sonar.language>java</sonar.language>
-    <spring.boot.version>2.6.15</spring.boot.version>
+    <spring.boot.version>2.7.18</spring.boot.version>
   </properties>
   <scm>
     <connection>scm:git:git://github.com/Dhi13man/spring-multi-data-source.git</connection>

--- a/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
@@ -113,15 +113,15 @@ public @interface EnableMultiDataSourceConfig {
     String dataSourceName() default "";
 
     /**
-     * The key/path of the data source class properties in the application properties file.
+     * The application properties key/path of the data source class properties.
      *
      * @return the prefix of the data source class properties in the application properties file.
      */
     String dataSourceClassPropertiesPath() default "spring.datasource.hikari";
 
     /**
-     * The key/path under which the JPA properties to override are located in the application
-     * properties file.
+     * The application properties key/path under which the JPA properties to override for this data
+     * source are located.
      * <p>
      * This allows overriding of the JPA properties for each data source. The properties under this
      * key will be merged with the usual properties under the spring.jpa.properties key.

--- a/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
@@ -18,8 +18,8 @@ public @interface EnableMultiDataSourceConfig {
    * This must be an exact package name, and not a prefix as custom entity managers can not
    * recursively scan entities inside nested packages.
    * <p>
-   * If {@link TargetDataSource} is used on any repository, the package of the entity that the
-   * repository is associated with will also be scanned for entities.
+   * If {@link TargetSecondaryDataSource} is used on any repository, the package of the entity that
+   * the repository is associated with will also be scanned for entities.
    *
    * @return the array of exact packages to scan for entities.
    */
@@ -74,15 +74,23 @@ public @interface EnableMultiDataSourceConfig {
   String generatedRepositoryPackagePrefix() default "";
 
   /**
-   * The array of {@link DataSourceConfig} annotations which contain the configuration for each data
-   * source.
+   * The config for the primary data source.
+   * <p>
+   * The primary data source is the data source which will be used by default for all repositories
+   * which do not have the {@link TargetSecondaryDataSource} annotation.
+   *
+   * @return the {@link DataSourceConfig} annotation for the primary data source.
+   */
+  DataSourceConfig primaryDataSourceConfig() default @DataSourceConfig(dataSourceName = "master");
+
+  /**
+   * The array of {@link DataSourceConfig} annotations which contain the configuration for each
+   * secondary data source.
    *
    * @return the array of {@link DataSourceConfig} annotations.
    * @see DataSourceConfig
    */
-  DataSourceConfig[] dataSourceConfigs() default {
-      @DataSourceConfig(dataSourceName = "master", isPrimary = true)
-  };
+  DataSourceConfig[] secondaryDataSourceConfigs() default {};
 
   @Retention(RetentionPolicy.RUNTIME)
   @Target({})
@@ -103,15 +111,6 @@ public @interface EnableMultiDataSourceConfig {
      * @return the name of the data source.
      */
     String dataSourceName() default "";
-
-    /**
-     * Whether this data source is the primary data source.
-     * <p>
-     * There must be exactly one primary data source.
-     *
-     * @return whether this data source is the primary data source.
-     */
-    boolean isPrimary() default false;
 
     /**
      * The key of the data source class properties in the application properties file.

--- a/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/annotations/EnableMultiDataSourceConfig.java
@@ -113,20 +113,21 @@ public @interface EnableMultiDataSourceConfig {
     String dataSourceName() default "";
 
     /**
-     * The key of the data source class properties in the application properties file.
+     * The key/path of the data source class properties in the application properties file.
      *
      * @return the prefix of the data source class properties in the application properties file.
      */
     String dataSourceClassPropertiesPath() default "spring.datasource.hikari";
 
     /**
-     * The path of the hibernate bean container property in the application properties.
+     * The key/path under which the JPA properties to override are located in the application
+     * properties file.
      * <p>
-     * This is needed to manually set the hibernate bean container to the spring bean container to
-     * ensure that the hibernate beans like attribute converters are managed by spring.
+     * This allows overriding of the JPA properties for each data source. The properties under this
+     * key will be merged with the usual properties under the spring.jpa.properties key.
      *
-     * @return the prefix of the hibernate bean container properties in the application properties
+     * @return the key under which the JPA properties to override are located.
      */
-    String hibernateBeanContainerPropertyPath() default "hibernate.resource.beans.container";
+    String overridingJpaPropertiesPath() default "spring.jpa.properties";
   }
 }

--- a/src/main/java/io/github/dhi13man/spring/datasource/annotations/TargetSecondaryDataSource.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/annotations/TargetSecondaryDataSource.java
@@ -9,20 +9,20 @@ import org.springframework.core.annotation.AliasFor;
 
 /**
  * Annotation to create copies of the repositories in the relevant packages, and autoconfigure them
- * to use the relevant data sources.
+ * to use the relevant secondary data sources.
  * <p>
  * Will generate all relevant boilerplate code and beans.
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)
-@Repeatable(TargetDataSources.class)
-public @interface TargetDataSource {
+@Repeatable(TargetSecondaryDataSources.class)
+public @interface TargetSecondaryDataSource {
 
   /**
    * Alias for dataSourceName, the name of the data source to use for the repository.
    * <p>
    * To use a data source other than the primary, it must have been configured in the
-   * {@link EnableMultiDataSourceConfig#dataSourceConfigs()} annotations.
+   * {@link EnableMultiDataSourceConfig#secondaryDataSourceConfigs()} annotations.
    *
    * @return the data source to use for the repository.
    * @see EnableMultiDataSourceConfig.DataSourceConfig#dataSourceName()

--- a/src/main/java/io/github/dhi13man/spring/datasource/annotations/TargetSecondaryDataSources.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/annotations/TargetSecondaryDataSources.java
@@ -7,18 +7,18 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to create copies of the repositories in the relevant packages, and autoconfigure them
- * to use the relevant data sources.
+ * to use the relevant secondary data sources.
  * <p>
  * Will generate all relevant boilerplate code and beans.
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.SOURCE)
-public @interface TargetDataSources {
+public @interface TargetSecondaryDataSources {
 
   /**
-   * The array of {@link TargetDataSource} annotations.
+   * The array of {@link TargetSecondaryDataSource} annotations.
    *
-   * @return the array of {@link TargetDataSource} annotations
+   * @return the array of {@link TargetSecondaryDataSource} annotations
    */
-  TargetDataSource[] value();
+  TargetSecondaryDataSource[] value();
 }

--- a/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
@@ -5,7 +5,6 @@
 
 package io.github.dhi13man.spring.datasource.config;
 
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -52,8 +51,11 @@ public interface IMultiDataSourceConfig {
   /**
    * Get the transaction manager to be used for the data source.
    *
-   * @param entityManagerFactory The entity manager factory, used to create the transaction manager
+   * @param entityManagerFactoryBean The entity manager factory bean, used to create the transaction
+   *                                 manager
    * @return The transaction manager.
    */
-  PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory);
+  PlatformTransactionManager transactionManager(
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  );
 }

--- a/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
@@ -5,6 +5,7 @@
 
 package io.github.dhi13man.spring.datasource.config;
 
+import java.util.Properties;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -25,6 +26,16 @@ public interface IMultiDataSourceConfig {
   DataSourceProperties dataSourceProperties();
 
   /**
+   * Get the JPA properties to override for the data source to be used.
+   * <p>
+   * This allows overriding of the JPA properties for each data source. These properties will be
+   * merged with the usual properties under the spring.jpa.properties key.
+   *
+   * @return The JPA properties.
+   */
+  Properties overridingJpaProperties();
+
+  /**
    * Get the {@link DataSource} instance for the data source to be used.
    * <p>
    * This is instantiated using the data source properties.
@@ -37,15 +48,19 @@ public interface IMultiDataSourceConfig {
   /**
    * Get the entity manager factory to be used to interface with the data source.
    *
-   * @param builder     The entity manager factory builder, used to build the entity manager
-   * @param beanFactory The bean factory, used to create the entity manager factory bean
-   * @param dataSource  The data source, used to create the entity manager factory bean
+   * @param builder               The entity manager factory builder, used to build the entity
+   *                              manager
+   * @param beanFactory           The bean factory, used to create the entity manager factory bean
+   * @param dataSource            The data source, used to create the entity manager factory bean
+   * @param overrideJpaProperties The JPA properties, used to create the entity manager factory
+   *                              bean
    * @return The entity manager factory bean.
    */
   LocalContainerEntityManagerFactoryBean entityManagerFactory(
+      Properties overrideJpaProperties,
+      DataSource dataSource,
       EntityManagerFactoryBuilder builder,
-      ConfigurableListableBeanFactory beanFactory,
-      DataSource dataSource
+      ConfigurableListableBeanFactory beanFactory
   );
 
   /**

--- a/src/main/java/io/github/dhi13man/spring/datasource/constants/MultiDataSourceErrorConstants.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/constants/MultiDataSourceErrorConstants.java
@@ -6,10 +6,6 @@ public final class MultiDataSourceErrorConstants {
       + " classes are annotated with @EnableMultiDataSourceConfig. Please annotate only one class"
       + " with this annotation and provide the data source configs.";
 
-  public static final String NOT_ONE_DATA_SOURCE_CONFIGS_MARKED_PRIMARY = " DataSourceConfigs"
-      + " marked as primary data source. Please mark exactly one @DataSourceConfig as primary data"
-      + " source in the datasourceConfigs property of @EnableMultiDataSourceConfig annotation.";
-
   public static final String MULTIPLE_CONFIG_ANNOTATIONS_FOR_ONE_DATASOURCE = "Multiple"
       + " @DataSourceConfigs annotations are provided for the same data source. Please"
       + " provide only one @DataSourceConfigs annotation for each data source.";
@@ -22,10 +18,15 @@ public final class MultiDataSourceErrorConstants {
       + " are provided in @EnableMultiDataSourceConfig.repositoryPackages. Please provide all"
       + " the packages (or a parent package) that hold your repositories.";
 
-  public static final String NO_REPOSITORY_METHOD_ANNOTATED_WITH_MULTI_DATA_SOURCE_REPOSITORY =
-      "No repository method is annotated with @TargetDataSource. Please annotate at least"
+  public static final String NO_REPOSITORY_METHOD_ANNOTATED_WITH_TARGET_SECONDARY_DATA_SOURCE =
+      "No repository method is annotated with @TargetSecondaryDataSource. Please annotate at least"
           + " one repository method with this annotation if you are using"
           + " @EnableMultiDataSourceConfig and want to segregate your repositories by data source.";
+
+  public static final String REPOSITORY_METHODS_SHOULD_NOT_HAVE_PRIMARY_DATA_SOURCE_AS_TARGET =
+      "Repository methods should not be annotated with @TargetSecondaryDataSource as the primary "
+          + "data source, as all repositories will use the primary data source by default. Please "
+          + "remove the @TargetSecondaryDataSource annotation from the following methods: ";
 
   private MultiDataSourceErrorConstants() {
   }

--- a/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
@@ -404,7 +404,7 @@ public class MultiDataSourceConfigGenerator {
 
     // Create the method parameters (EntityManagerFactory dependency)
     final ParameterSpec entityManagerFactoryParameter = ParameterSpec
-        .builder(EntityManagerFactory.class, "entityManagerFactory")
+        .builder(LocalContainerEntityManagerFactoryBean.class, "entityManagerFactoryBean")
         .addAnnotation(qualifierAnnotation)
         .build();
 
@@ -416,7 +416,7 @@ public class MultiDataSourceConfigGenerator {
         .returns(PlatformTransactionManager.class)
         .addParameter(entityManagerFactoryParameter)
         .addStatement(
-            "return new $T($N)",
+            "return new $T($N.getNativeEntityManagerFactory())",
             JpaTransactionManager.class,
             entityManagerFactoryParameter
         );

--- a/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
@@ -206,7 +206,7 @@ public class MultiDataSourceConfigGenerator {
     final MethodSpec entityManagerFactoryMethod = addPrimaryAnnotationIfPrimaryConfigAndBuild(
         createEntityManagerFactoryBeanMethod(
             entityManagerFactoryBeanNameField,
-            dataSourceEntityPackageField,
+            dataSourceBeanNameField,
             overrideJpaPropertiesBeanNameField,
             dataSourceEntityPackageField,
             hibernateBeanContainerPropertyField

--- a/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceRepositoryGenerator.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceRepositoryGenerator.java
@@ -8,8 +8,8 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSource;
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSources;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSources;
 import io.github.dhi13man.spring.datasource.utils.MultiDataSourceCommonStringUtils;
 import io.github.dhi13man.spring.datasource.utils.MultiDataSourceGeneratorUtils;
 import java.util.HashSet;
@@ -32,7 +32,8 @@ import org.springframework.stereotype.Repository;
 
 /**
  * Annotation processor to generate config classes for all the repositories annotated with
- * {@link TargetDataSource} and create copies of the repositories in the relevant packages.
+ * {@link TargetSecondaryDataSource} and create copies of the repositories in the relevant
+ * packages.
  */
 public class MultiDataSourceRepositoryGenerator {
 
@@ -257,13 +258,13 @@ public class MultiDataSourceRepositoryGenerator {
    */
   private MethodSpec convertExecutableMethodElementToMethodSpec(ExecutableElement method) {
     // Copy all annotations other than the ones used to mark the method as a repository method
-    // (i.e. @TargetDataSources and @TargetDataSource)
+    // (i.e. @TargetSecondaryDataSources and @TargetSecondaryDataSource)
     final List<AnnotationSpec> annotationsToSpec = method.getAnnotationMirrors().stream()
         .map(AnnotationSpec::get)
         .filter(
             annotationSpec -> !Set.of(
-                TypeName.get(TargetDataSources.class),
-                TypeName.get(TargetDataSource.class)
+                TypeName.get(TargetSecondaryDataSources.class),
+                TypeName.get(TargetSecondaryDataSource.class)
             ).contains(annotationSpec.type)
         )
         .collect(Collectors.toList());

--- a/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
@@ -94,6 +94,7 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
    * @param filer               the filer to use for writing files
    * @param messager            the messager to use for printing messages
    * @param elementUtils        the element utils to use for getting packages
+   * @param typeUtils           the type utils to use for getting types
    * @param commonStringUtils   Utility class for common string operations
    * @param generatorUtils      Utility class for generating code for the Multi Data Source library
    * @param configGenerator     the Multi Data Source config generator

--- a/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
@@ -337,8 +337,8 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
         .requireNonNullElse(annotation.secondaryDataSourceConfigs(), new DataSourceConfig[]{});
 
     // Validate that there is exactly one primary data source config
-    final boolean isPrimaryDataSourceNeverSecondaryDataSource = Stream.of(
-            secondaryDataSourceConfigs)
+    final boolean isPrimaryDataSourceNeverSecondaryDataSource = Stream
+        .of(secondaryDataSourceConfigs)
         .noneMatch(config -> primaryConfig.dataSourceName().equals(config.dataSourceName()));
     if (isPrimaryDataSourceNeverSecondaryDataSource) {
       return primaryConfig;
@@ -544,12 +544,12 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
       Map<String, Set<ExecutableElement>> dataSourceToTargetRepositoryMethodMap,
       Map<String, DataSourceConfig> dataSourceConfigMap
   ) {
-    final Set<String> dataSourcesWithoutConfig = dataSourceToTargetRepositoryMethodMap.keySet()
-        .stream()
-        .filter(dataSourceName -> !dataSourceConfigMap.containsKey(dataSourceName))
-        .collect(Collectors.toSet());
-    if (!dataSourcesWithoutConfig.isEmpty()) {
-      final String errorMessage = "No config found for data sources: " + dataSourcesWithoutConfig
+    for (final String dataSourceName : dataSourceToTargetRepositoryMethodMap.keySet()) {
+      if (dataSourceConfigMap.containsKey(dataSourceName)) {
+        continue;
+      }
+
+      final String errorMessage = "No config found for data source: " + dataSourceName
           + ". Please provide a @DataSourceConfig for each data source in the"
           + " @EnableMultiDataSourceConfig annotation.";
       messager.printMessage(Kind.ERROR, errorMessage);

--- a/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessor.java
@@ -2,18 +2,18 @@ package io.github.dhi13man.spring.datasource.processor;
 
 import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.MULTIPLE_CLASSES_ANNOTATED_WITH_ENABLE_CONFIG_ANNOTATION;
 import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.MULTIPLE_CONFIG_ANNOTATIONS_FOR_ONE_DATASOURCE;
-import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.NOT_ONE_DATA_SOURCE_CONFIGS_MARKED_PRIMARY;
 import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.NO_ENTITY_PACKAGES_PROVIDED_IN_CONFIG;
-import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.NO_REPOSITORY_METHOD_ANNOTATED_WITH_MULTI_DATA_SOURCE_REPOSITORY;
+import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.NO_REPOSITORY_METHOD_ANNOTATED_WITH_TARGET_SECONDARY_DATA_SOURCE;
 import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.NO_REPOSITORY_PACKAGES_PROVIDED_IN_CONFIG;
+import static io.github.dhi13man.spring.datasource.constants.MultiDataSourceErrorConstants.REPOSITORY_METHODS_SHOULD_NOT_HAVE_PRIMARY_DATA_SOURCE_AS_TARGET;
 
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import io.github.dhi13man.spring.datasource.annotations.EnableMultiDataSourceConfig;
 import io.github.dhi13man.spring.datasource.annotations.EnableMultiDataSourceConfig.DataSourceConfig;
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSource;
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSources;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSources;
 import io.github.dhi13man.spring.datasource.dto.EnableConfigAnnotationAndElementHolder;
 import io.github.dhi13man.spring.datasource.generators.MultiDataSourceConfigGenerator;
 import io.github.dhi13man.spring.datasource.generators.MultiDataSourceRepositoryGenerator;
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -47,7 +48,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * Annotation processor to generate config classes for all the repositories annotated with
- * {@link TargetDataSource} and create copies of the repositories in the relevant packages.
+ * {@link TargetSecondaryDataSource} and create copies of the repositories in the relevant
+ * packages.
  */
 @AutoService(Processor.class)
 public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
@@ -59,6 +61,8 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
   private static final String CONFIG_PACKAGE_SUFFIX = ".generated.config";
 
   private static final String REPOSITORIES_PACKAGE_SUFFIX = ".generated.repositories";
+
+  private static final String ERROR_WHILE_WRITING_THE_CLASS = "Error while writing the class: ";
 
   private Filer filer;
 
@@ -144,7 +148,8 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
   /**
    * {@inheritDoc}
    * <p>
-   * Performs the following tasks for each {@link TargetDataSource} annotated repository method:
+   * Performs the following tasks for each {@link TargetSecondaryDataSource} annotated repository
+   * method:
    * <p>
    * 1. Aggregates the list of data sources to be used throughout the system
    * <p>
@@ -160,7 +165,7 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
    */
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    // Get the element annotated with @EnableMultiDataSourceConfig and validate count
+    // Get the element annotated with @EnableMultiDataSourceConfig and validate
     final EnableConfigAnnotationAndElementHolder holder =
         validateAndGetEnableConfigAnnotationAndElementHolder(roundEnv);
     // No holder means no annotation found
@@ -170,49 +175,47 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
     final EnableMultiDataSourceConfig annotation = holder.getAnnotation();
     final Element annotatedElement = holder.getAnnotatedElement();
 
-    // Get the primary data source config and the data source config map
-    final List<DataSourceConfig> dataSourceConfigs = List
-        .of(Objects.requireNonNullElse(annotation.dataSourceConfigs(), new DataSourceConfig[0]));
-    final DataSourceConfig primaryDataSourceConfig =
-        validateAndGetPrimaryDataSourceConfig(dataSourceConfigs);
-    final Map<String, DataSourceConfig> secondaryDataSourceConfigMap =
-        createDataSourceToConfigMap(dataSourceConfigs);
-
-    // Create primary data source configuration class
+    // Create the primary data source config class
+    final DataSourceConfig primaryConfig = validateAndGetPrimaryDataSourceConfig(annotation);
     final PackageElement annotatedElementPackage = elementUtils.getPackageOf(annotatedElement);
     final String nonEmptyGeneratedRepositoryPackagePrefix =
         getGeneratedRepositoryPackagePrefix(annotation, annotatedElementPackage);
     final String nonEmptyGeneratedConfigPackage =
         getGeneratedConfigPackage(annotation, annotatedElementPackage);
     createDataSourceConfigurationClass(
-        primaryDataSourceConfig,
+        primaryConfig,
         annotation,
         nonEmptyGeneratedConfigPackage,
         annotation.repositoryPackages(), // For primary data source, scan all the packages provided
         new String[]{nonEmptyGeneratedRepositoryPackagePrefix} // Generated repos excluded from scan
     );
-    secondaryDataSourceConfigMap.remove(primaryDataSourceConfig.dataSourceName());
 
-    // Get secondary data source to target repository method elements map
+    // Get the data source config maps
+    final List<DataSourceConfig> secondaryDataSourceConfigs = List
+        .of(annotation.secondaryDataSourceConfigs());
     final Map<String, Set<ExecutableElement>> dataSourceToTargetRepositoryMethodMap =
-        createDataSourceToTargetRepositoryMethodMap(roundEnv, secondaryDataSourceConfigMap);
-    // Generate configs for those data sources that do not have @TargetDataSource
-    secondaryDataSourceConfigMap.keySet().stream()
-        .filter(dataSource -> !dataSourceToTargetRepositoryMethodMap.containsKey(dataSource))
-        .map(secondaryDataSourceConfigMap::get)
+        createDataSourceToTargetRepositoryMethodMap(roundEnv, primaryConfig);
+    final Map<String, DataSourceConfig> secondaryDataSourceConfigMap =
+        createDataSourceToConfigMap(secondaryDataSourceConfigs);
+    validateDataSourceConfigs(dataSourceToTargetRepositoryMethodMap, secondaryDataSourceConfigMap);
+
+    // Generate configs for those data sources that do not have @TargetSecondaryDataSource
+    secondaryDataSourceConfigMap.entrySet().stream()
+        .filter(entry -> !dataSourceToTargetRepositoryMethodMap.containsKey(entry.getKey()))
         .forEach(
-            config -> createDataSourceConfigurationClass(
-                config,
+            // All repositories scanned and excluded as no @TargetSecondaryDataSource
+            dataSourceConfigEntry -> createDataSourceConfigurationClass(
+                dataSourceConfigEntry.getValue(),
                 annotation,
                 nonEmptyGeneratedConfigPackage,
-                annotation.repositoryPackages(), // All repos scanned as no @TargetDataSource
-                annotation.repositoryPackages() // All repos excluded as no @TargetDataSource
+                annotation.repositoryPackages(),
+                annotation.repositoryPackages()
             )
         );
     if (dataSourceToTargetRepositoryMethodMap.isEmpty()) {
       messager.printMessage(
           Kind.NOTE,
-          NO_REPOSITORY_METHOD_ANNOTATED_WITH_MULTI_DATA_SOURCE_REPOSITORY
+          NO_REPOSITORY_METHOD_ANNOTATED_WITH_TARGET_SECONDARY_DATA_SOURCE
       );
       return false;
     }
@@ -274,7 +277,8 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
   public Set<String> getSupportedAnnotationTypes() {
     return Set.of(
         EnableMultiDataSourceConfig.class.getCanonicalName(),
-        TargetDataSource.class.getCanonicalName()
+        TargetSecondaryDataSource.class.getCanonicalName(),
+        TargetSecondaryDataSources.class.getCanonicalName()
     );
   }
 
@@ -312,26 +316,33 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
     return new EnableConfigAnnotationAndElementHolder(annotatedElement, annotation);
   }
 
+
   /**
-   * Validates that there is exactly one data source config marked as primary and returns it if
-   * found.
+   * Validates that there is exactly one primary data source config and returns it.
    *
-   * @param dataSourceConfigs list of {@link DataSourceConfig}s
-   * @return the primary data source config
+   * @param annotation the {@link EnableMultiDataSourceConfig} annotation
+   * @return the primary {@link DataSourceConfig}
    */
   private DataSourceConfig validateAndGetPrimaryDataSourceConfig(
-      List<DataSourceConfig> dataSourceConfigs
+      EnableMultiDataSourceConfig annotation
   ) {
-    final List<DataSourceConfig> primaryDataSourceConfigs = dataSourceConfigs.stream()
-        .filter(DataSourceConfig::isPrimary)
-        .collect(Collectors.toList());
-    if (primaryDataSourceConfigs.size() != 1) {
-      final String noConfigForPrimaryDataSourceMessage = primaryDataSourceConfigs.size()
-          + NOT_ONE_DATA_SOURCE_CONFIGS_MARKED_PRIMARY;
-      messager.printMessage(Kind.ERROR, noConfigForPrimaryDataSourceMessage);
-      throw new IllegalArgumentException(noConfigForPrimaryDataSourceMessage);
+    final DataSourceConfig primaryConfig = annotation.primaryDataSourceConfig();
+    final DataSourceConfig[] secondaryDataSourceConfigs = Objects
+        .requireNonNullElse(annotation.secondaryDataSourceConfigs(), new DataSourceConfig[]{});
+
+    // Validate that there is exactly one primary data source config
+    final boolean isPrimaryDataSourceNeverSecondaryDataSource = Stream.of(
+            secondaryDataSourceConfigs)
+        .noneMatch(config -> primaryConfig.dataSourceName().equals(config.dataSourceName()));
+    if (isPrimaryDataSourceNeverSecondaryDataSource) {
+      return primaryConfig;
     }
-    return primaryDataSourceConfigs.get(0);
+
+    final String errorMessage = "Primary data source " + primaryConfig.dataSourceName()
+        + " is also marked as a secondary data source. Please do not mark the primary data source"
+        + " as a secondary data source in the @EnableMultiDataSourceConfig annotation.";
+    messager.printMessage(Kind.ERROR, errorMessage);
+    throw new IllegalArgumentException(errorMessage);
   }
 
   /**
@@ -439,9 +450,11 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
     }
 
     // Create the data source config class
+    final boolean isPrimaryConfig = dataSourceName
+        .equals(annotation.primaryDataSourceConfig().dataSourceName());
     final TypeSpec configurationTypeSpec = configGenerator.generateMultiDataSourceConfigTypeElement(
         dataSourceConfig,
-        dataSourceName,
+        isPrimaryConfig,
         dataSourceConfigClassName,
         dataSourceConfigPropertiesPath,
         repositoryPackagesToIncludeInScan,
@@ -455,46 +468,44 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
 
   /**
    * Creates a map of the data source name to the set of ExecutableElements that are annotated with
-   * {@link TargetDataSource} for that data source.
+   * {@link TargetSecondaryDataSource} for that data source.
    * <p>
-   * Targets all Classes annotated with {@link TargetDataSource} or its container annotation. Return
-   * a map grouped by the data source name to the set of ExecutableElements that are annotated with
-   * {@link TargetDataSource} for that data source.
+   * Targets all Classes annotated with {@link TargetSecondaryDataSource} or its container
+   * annotation. Return a map grouped by the data source name to the set of ExecutableElements that
+   * are annotated with {@link TargetSecondaryDataSource} for that data source.
    *
-   * @param roundEnv            environment for information about the current and prior round
-   * @param dataSourceConfigMap map of the data source name to the {@link DataSourceConfig}
-   *                            associated with it
+   * @param roundEnv environment for information about the current and prior round
    * @return map of the data source name to the set of ExecutableElements that are annotated with
    */
   private Map<String, Set<ExecutableElement>> createDataSourceToTargetRepositoryMethodMap(
       RoundEnvironment roundEnv,
-      Map<String, DataSourceConfig> dataSourceConfigMap
+      DataSourceConfig primaryDataSourceConfig
   ) {
-    // Deal with individual @TargetDataSource annotations
+    // Deal with individual @TargetSecondaryDataSource annotations
     final Map<String, Set<ExecutableElement>> targetDataSourceAnnotatedMethodMap = roundEnv
-        .getElementsAnnotatedWith(TargetDataSource.class)
+        .getElementsAnnotatedWith(TargetSecondaryDataSource.class)
         .stream()
         .filter(element -> element instanceof ExecutableElement)
         .map(ExecutableElement.class::cast)
         .collect(
             Collectors.groupingBy(
-                x -> x.getAnnotation(TargetDataSource.class).value(),
+                x -> x.getAnnotation(TargetSecondaryDataSource.class).value(),
                 Collectors.toSet()
             )
         );
 
-    // Deal with @TargetDataSources container annotations
+    // Deal with @TargetSecondaryDataSources container annotations
     final Set<ExecutableElement> annotatedElements = roundEnv
-        .getElementsAnnotatedWith(TargetDataSources.class)
+        .getElementsAnnotatedWith(TargetSecondaryDataSources.class)
         .stream()
         .filter(element -> element instanceof ExecutableElement)
         .map(ExecutableElement.class::cast)
         .collect(Collectors.toSet());
     for (final ExecutableElement element : annotatedElements) {
-      final TargetDataSources repositoriesAnnotation = element
-          .getAnnotation(TargetDataSources.class);
+      final TargetSecondaryDataSources repositoriesAnnotation = element
+          .getAnnotation(TargetSecondaryDataSources.class);
       final List<String> dataSourcesInvolved = Arrays.stream(repositoriesAnnotation.value())
-          .map(TargetDataSource::value)
+          .map(TargetSecondaryDataSource::value)
           .collect(Collectors.toList());
       for (final String dataSourceName : dataSourcesInvolved) {
         final Set<ExecutableElement> executableElements = targetDataSourceAnnotatedMethodMap
@@ -504,8 +515,30 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
       }
     }
 
-    // Validate that all the data sources involved have a config
-    final Set<String> dataSourcesWithoutConfig = targetDataSourceAnnotatedMethodMap.keySet()
+    if (targetDataSourceAnnotatedMethodMap.containsKey(primaryDataSourceConfig.dataSourceName())) {
+      final String errorMessage = REPOSITORY_METHODS_SHOULD_NOT_HAVE_PRIMARY_DATA_SOURCE_AS_TARGET
+          + targetDataSourceAnnotatedMethodMap.get(primaryDataSourceConfig.dataSourceName());
+      messager.printMessage(Kind.ERROR, errorMessage);
+      throw new IllegalArgumentException(errorMessage);
+    }
+    return targetDataSourceAnnotatedMethodMap;
+  }
+
+  /**
+   * Validates that there is a {@link DataSourceConfig} for each data source being targeted by
+   * {@link TargetSecondaryDataSource} annotations.
+   *
+   * @param dataSourceToTargetRepositoryMethodMap map of the data source name to the set of
+   *                                              {@link ExecutableElement}s that are annotated with
+   *                                              {@link TargetSecondaryDataSource}
+   * @param dataSourceConfigMap                   map of the data source name to the
+   *                                              {@link DataSourceConfig}
+   */
+  private void validateDataSourceConfigs(
+      Map<String, Set<ExecutableElement>> dataSourceToTargetRepositoryMethodMap,
+      Map<String, DataSourceConfig> dataSourceConfigMap
+  ) {
+    final Set<String> dataSourcesWithoutConfig = dataSourceToTargetRepositoryMethodMap.keySet()
         .stream()
         .filter(dataSourceName -> !dataSourceConfigMap.containsKey(dataSourceName))
         .collect(Collectors.toSet());
@@ -516,17 +549,16 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
       messager.printMessage(Kind.ERROR, errorMessage);
       throw new IllegalArgumentException(errorMessage);
     }
-    return targetDataSourceAnnotatedMethodMap;
   }
 
   /**
    * Creates a map of the {@link TypeElement} to the set of {@link ExecutableElement}s that are
-   * annotated with {@link TargetDataSource}.
+   * annotated with {@link TargetSecondaryDataSource}.
    *
    * @param executableElements set of {@link ExecutableElement}s that are annotated with
-   *                           {@link TargetDataSource}
+   *                           {@link TargetSecondaryDataSource}
    * @return map of the {@link TypeElement} to the set of {@link ExecutableElement}s that are
-   * annotated with {@link TargetDataSource}
+   * annotated with {@link TargetSecondaryDataSource}
    */
   private Map<TypeElement, Set<ExecutableElement>> createTypeElementToExecutableElementsMap(
       Set<ExecutableElement> executableElements
@@ -588,8 +620,8 @@ public class MultiDataSourceAnnotationProcessor extends AbstractProcessor {
     try {
       JavaFile.builder(targetPackage, typeSpec).build().writeTo(filer);
     } catch (IOException e) {
-      messager.printMessage(Kind.ERROR, "Error while writing the class: " + e);
-      throw new IllegalStateException("Error while writing the class: " + e);
+      messager.printMessage(Kind.ERROR, ERROR_WHILE_WRITING_THE_CLASS + e);
+      throw new IllegalStateException(ERROR_WHILE_WRITING_THE_CLASS + e);
     }
   }
 

--- a/src/test/java/io/github/dhi13man/spring/datasource/config/MultiDataSourceTestConfig.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/config/MultiDataSourceTestConfig.java
@@ -12,8 +12,8 @@ import io.github.dhi13man.spring.datasource.annotations.EnableMultiDataSourceCon
     repositoryPackages = "io.github.dhi13man.spring.datasource.generators", // MockRepository is repository
     generatedConfigPackage = "io.github.dhi13man.spring.datasource.generated.config",
     generatedRepositoryPackagePrefix = "io.github.dhi13man.spring.datasource.generated.repositories",
-    dataSourceConfigs = {
-        @DataSourceConfig(dataSourceName = "master", isPrimary = true),
+    primaryDataSourceConfig = @DataSourceConfig(dataSourceName = "master"),
+    secondaryDataSourceConfigs = {
         @DataSourceConfig(dataSourceName = "replica-2"),
         @DataSourceConfig(dataSourceName = "read-replica"),
         @DataSourceConfig(dataSourceName = "replica-no-target-data-source"),

--- a/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
@@ -8,6 +8,7 @@ import io.github.dhi13man.spring.datasource.generated.config.Replica2DataSourceC
 import io.github.dhi13man.spring.datasource.generated.config.ReplicaNoTargetDataSourceDataSourceConfig;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
@@ -83,10 +84,14 @@ class MultiDataSourceConfigGeneratorTest {
       final DataSourceProperties dataSourceProperties = generatedConfig.dataSourceProperties();
       dataSourceProperties.setEmbeddedDatabaseConnection(EmbeddedDatabaseConnection.H2);
       dataSourceProperties.setType(SingleConnectionDataSource.class);
-
+      final Properties overrideJpaProperties = generatedConfig.overridingJpaProperties();
       final DataSource dataSource = generatedConfig.dataSource(dataSourceProperties);
-      final LocalContainerEntityManagerFactoryBean entityManagerFactory = generatedConfig
-          .entityManagerFactory(mockEntityManagerFactoryBuilder, mockBeanFactory, dataSource);
+      final LocalContainerEntityManagerFactoryBean entityManagerFactory = generatedConfig.entityManagerFactory(
+          overrideJpaProperties,
+          dataSource,
+          mockEntityManagerFactoryBuilder,
+          mockBeanFactory
+      );
 
       // Assert
       Assertions.assertNotNull(entityManagerFactory);

--- a/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
@@ -1,6 +1,6 @@
 package io.github.dhi13man.spring.datasource.generators;
 
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSource;
 import io.github.dhi13man.spring.datasource.config.IMultiDataSourceConfig;
 import io.github.dhi13man.spring.datasource.generated.config.MasterDataSourceConfig;
 import io.github.dhi13man.spring.datasource.generated.config.ReadReplicaDataSourceConfig;
@@ -114,7 +114,7 @@ class MultiDataSourceConfigGeneratorTest {
   public interface MockConfigTestRepository extends JpaRepository<Object, Long> {
 
     @Override
-    @TargetDataSource("read-replica")
+    @TargetSecondaryDataSource("read-replica")
     @NonNull
     List<Object> findAll();
   }

--- a/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
@@ -9,7 +9,6 @@ import io.github.dhi13man.spring.datasource.generated.config.ReplicaNoTargetData
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -99,8 +98,10 @@ class MultiDataSourceConfigGeneratorTest {
 
     for (final IMultiDataSourceConfig generatedConfig : generatedConfigs) {
       // Arrange
-      final EntityManagerFactory mockEntityManagerFactory = Mockito
-          .mock(EntityManagerFactory.class);
+      final LocalContainerEntityManagerFactoryBean mockEntityManagerFactory = Mockito
+          .mock(LocalContainerEntityManagerFactoryBean.class);
+      Mockito.when(mockEntityManagerFactory.getNativeEntityManagerFactory())
+          .thenReturn(Mockito.mock());
 
       // Act
       final PlatformTransactionManager transactionManager = generatedConfig

--- a/src/test/java/io/github/dhi13man/spring/datasource/generators/TargetSecondaryDataSourceGeneratorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/generators/TargetSecondaryDataSourceGeneratorTest.java
@@ -1,6 +1,6 @@
 package io.github.dhi13man.spring.datasource.generators;
 
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSource;
 import io.github.dhi13man.spring.datasource.generated.repositories.read_replica.ReadReplicaMockConfigTestRepository;
 import io.github.dhi13man.spring.datasource.generated.repositories.replica_2.Replica2MockRepositoryTestRepository;
 import java.lang.reflect.Method;
@@ -12,7 +12,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
 
-class TargetDataSourceGeneratorTest {
+class TargetSecondaryDataSourceGeneratorTest {
 
   @Test
   void generateRepositoryTypeElementWithAnnotatedMethods() {
@@ -54,7 +54,7 @@ class TargetDataSourceGeneratorTest {
     // Replica2MockConfigTestRepository (as it overrides the findAll method of JpaRepository).
     //
     // However, the findAll method of Replica2MockConfigTestRepository will throw an exception
-    // as it is annotated only with @TargetDataSource("read-replica"). Hence, the method
+    // as it is annotated only with @TargetSecondaryDataSource("read-replica"). Hence, the method
     // is disabled in the Replica2MockConfigTestRepository generated class.
     final Optional<Method> findAllMockConfigTestRepository = ReflectionUtils.findMethod(
         mockConfigTestRepositoryClass,
@@ -76,11 +76,11 @@ class TargetDataSourceGeneratorTest {
 
   public interface MockRepositoryTestRepository extends JpaRepository<String, Long> {
 
-    @TargetDataSource("replica-2")
+    @TargetSecondaryDataSource("replica-2")
     Object findByCustomObjectId(long customObjectId);
 
     @Override
-    @TargetDataSource("read-replica")
+    @TargetSecondaryDataSource("read-replica")
     @NonNull
     List<String> findAll();
   }

--- a/src/test/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessorTest.java
@@ -19,6 +19,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -44,6 +45,8 @@ class MultiDataSourceAnnotationProcessorTest {
 
   private final Elements mockElementUtils = Mockito.mock(Elements.class);
 
+  private final Types mockTypeUtils = Mockito.mock(Types.class);
+
   private final MultiDataSourceCommonStringUtils mockStringUtils = Mockito
       .mock(MultiDataSourceCommonStringUtils.class);
 
@@ -60,6 +63,7 @@ class MultiDataSourceAnnotationProcessorTest {
       mockFiler,
       mockMessager,
       mockElementUtils,
+      mockTypeUtils,
       mockStringUtils,
       mockGeneratorUtils,
       mockConfigGenerator,

--- a/src/test/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/processor/MultiDataSourceAnnotationProcessorTest.java
@@ -3,7 +3,8 @@ package io.github.dhi13man.spring.datasource.processor;
 import com.squareup.javapoet.TypeSpec;
 import io.github.dhi13man.spring.datasource.annotations.EnableMultiDataSourceConfig;
 import io.github.dhi13man.spring.datasource.annotations.EnableMultiDataSourceConfig.DataSourceConfig;
-import io.github.dhi13man.spring.datasource.annotations.TargetDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSource;
+import io.github.dhi13man.spring.datasource.annotations.TargetSecondaryDataSources;
 import io.github.dhi13man.spring.datasource.generators.MultiDataSourceConfigGenerator;
 import io.github.dhi13man.spring.datasource.generators.MultiDataSourceRepositoryGenerator;
 import io.github.dhi13man.spring.datasource.utils.MultiDataSourceCommonStringUtils;
@@ -110,10 +111,7 @@ class MultiDataSourceAnnotationProcessorTest {
         .thenReturn(mockAnnotation);
     final DataSourceConfig mockDataSourceConfig = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig.isPrimary()).thenReturn(true);
-    Mockito.when(mockAnnotation.dataSourceConfigs()).thenReturn(new DataSourceConfig[]{
-        mockDataSourceConfig
-    });
+    Mockito.when(mockAnnotation.primaryDataSourceConfig()).thenReturn(mockDataSourceConfig);
 
     // Act and Assert IllegalArgumentException thrown
     Assertions.assertThrows(
@@ -141,10 +139,7 @@ class MultiDataSourceAnnotationProcessorTest {
         .thenReturn(mockAnnotation);
     final DataSourceConfig mockDataSourceConfig = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig.isPrimary()).thenReturn(true);
-    Mockito.when(mockAnnotation.dataSourceConfigs()).thenReturn(new DataSourceConfig[]{
-        mockDataSourceConfig
-    });
+    Mockito.when(mockAnnotation.primaryDataSourceConfig()).thenReturn(mockDataSourceConfig);
 
     // Act and Assert IllegalArgumentException thrown
     Assertions.assertThrows(
@@ -175,15 +170,14 @@ class MultiDataSourceAnnotationProcessorTest {
         .thenReturn(mockAnnotation);
     final DataSourceConfig mockDataSourceConfig = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig.isPrimary()).thenReturn(true);
-    Mockito.when(mockAnnotation.dataSourceConfigs()).thenReturn(new DataSourceConfig[]{
+    Mockito.when(mockAnnotation.secondaryDataSourceConfigs()).thenReturn(new DataSourceConfig[]{
         mockDataSourceConfig
     });
     final TypeSpec mockConfigTypeSpec = TypeSpec.classBuilder("MockConfig").build();
     Mockito.when(
         mockConfigGenerator.generateMultiDataSourceConfigTypeElement(
             mockDataSourceConfig,
-            MOCK_MASTER_DATA_SOURCE_NAME,
+            false,
             MOCK_MASTER_DATA_SOURCE_CONFIG_CLASS_NAME,
             MOCK_DATASOURCE_PROPERTIES_PREFIX + "." + MOCK_MASTER_DATA_SOURCE_NAME,
             mockPackages,
@@ -219,14 +213,11 @@ class MultiDataSourceAnnotationProcessorTest {
     Mockito.when(mockAnnotation.repositoryPackages()).thenReturn(mockPackages);
     final DataSourceConfig mockDataSourceConfig1 = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig1.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig1.isPrimary()).thenReturn(true);
     final DataSourceConfig mockDataSourceConfig2 = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig2.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig2.isPrimary()).thenReturn(false);
-    Mockito.when(mockAnnotation.dataSourceConfigs()).thenReturn(new DataSourceConfig[]{
-        mockDataSourceConfig1,
-        mockDataSourceConfig2
-    });
+    Mockito.when(mockAnnotation.primaryDataSourceConfig()).thenReturn(mockDataSourceConfig1);
+    Mockito.when(mockAnnotation.secondaryDataSourceConfigs())
+        .thenReturn(new DataSourceConfig[]{mockDataSourceConfig2});
 
     // Act and Assert
     Assertions.assertThrows(
@@ -252,11 +243,9 @@ class MultiDataSourceAnnotationProcessorTest {
         .thenReturn(mockAnnotation);
     final DataSourceConfig mockDataSourceConfig1 = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig1.dataSourceName()).thenReturn(MOCK_MASTER_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig1.isPrimary()).thenReturn(true);
     final DataSourceConfig mockDataSourceConfig2 = Mockito.mock(DataSourceConfig.class);
     Mockito.when(mockDataSourceConfig2.dataSourceName()).thenReturn(MOCK_SLAVE_DATA_SOURCE_NAME);
-    Mockito.when(mockDataSourceConfig2.isPrimary()).thenReturn(false);
-    Mockito.when(mockAnnotation.dataSourceConfigs()).thenReturn(new DataSourceConfig[]{
+    Mockito.when(mockAnnotation.secondaryDataSourceConfigs()).thenReturn(new DataSourceConfig[]{
         mockDataSourceConfig1,
         mockDataSourceConfig2
     });
@@ -295,7 +284,8 @@ class MultiDataSourceAnnotationProcessorTest {
     processor.init(mockProcessingEnvironment);
     final Set<String> expectedAnnotationTypes = Set.of(
         EnableMultiDataSourceConfig.class.getCanonicalName(),
-        TargetDataSource.class.getCanonicalName()
+        TargetSecondaryDataSource.class.getCanonicalName(),
+        TargetSecondaryDataSources.class.getCanonicalName()
     );
 
     // Act


### PR DESCRIPTION
- [Better Organise DataSourceConfig to segregate Primary and Secondary data sources as per Spring Convention.](https://github.com/Dhi13man/spring-multi-data-source/commit/6960eed859f4a321b0d6eda00dd3051997eb1363)
- [Allow @TargetSecondaryDataSource to be placed on any Repository, not just JpaRepository.](https://github.com/Dhi13man/spring-multi-data-source/commit/39591ade2902cade09a0c9099fc9c9f5e3aeefb3)
- [Adaptive EntityManagerFactory for TransactionManager based on LocalContainerEntityManagerFactoryBean generated. Decoupled from Javax/Jakarta.](https://github.com/Dhi13man/spring-multi-data-source/commit/cd6bc801a6c98d038d080c477ed08ade30c96fd2)
- [Allow possibility for overriding different JPA properties for each data source](https://github.com/Dhi13man/spring-multi-data-source/pull/21/commits/5005cdeaaec0f154c47904d4bbf31f29b703bdf2)
- [Ready for v0.2.1 release.](https://github.com/Dhi13man/spring-multi-data-source/pull/21/commits/19cc3e4aa82354a75d3599555f99e6e314634cfe)