### PR TITLE
Release v0.3.3 | spring-multi-data-source Java 17+ support

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,12 @@
 # Releases
 
+## [0.3.3] - 5th August 2024
+
+- Java 17+ Support: Added support for Java 17+ by abstracting away all usages
+  of `javax.persistence`. This is to ensure that the library is compatible with the latest Java
+  versions.
+    - This is a minor change and should not affect any existing implementations.
+
 ## [0.3.2] - 4th August 2024
 
 - **HOTFIX:** Replaced the use of native entity manager factory

--- a/pom.xml
+++ b/pom.xml
@@ -233,5 +233,5 @@
   </scm>
 
   <url>http://www.github.com/dhi13man/spring-multi-data-source</url>
-  <version>0.3.2</version>
+  <version>0.3.3</version>
 </project>

--- a/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/config/IMultiDataSourceConfig.java
@@ -1,7 +1,6 @@
 package io.github.dhi13man.spring.datasource.config;
 
 import java.util.Properties;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -62,8 +61,11 @@ public interface IMultiDataSourceConfig {
   /**
    * Get the transaction manager to be used for the data source.
    *
-   * @param entityManagerFactory The entity manager factory used to create the transaction manager
+   * @param entityManagerFactoryBean The entity manager factory bean whose EntityManagerFactory
+   *                                 object is used to create the transaction manager
    * @return The transaction manager.
    */
-  PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory);
+  PlatformTransactionManager transactionManager(
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  );
 }

--- a/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
@@ -434,9 +434,8 @@ public class MultiDataSourceConfigGenerator {
    * Create the {@link MethodSpec} builder for the {@link LocalContainerEntityManagerFactoryBean}
    * bean.
    * <p>
-   * {@link LocalContainerEntityManagerFactoryBean} will determine the
-   * {@link javax.persistence.EntityManager} implementation to use based on the {@link DataSource}
-   * implementation for complex queries.
+   * {@link LocalContainerEntityManagerFactoryBean} will determine the EntityManager implementation
+   * to use based on the {@link DataSource} implementation for complex queries.
    *
    * @param beanNameFieldSpece                      the {@link FieldSpec} for this bean name
    *                                                constant
@@ -449,6 +448,7 @@ public class MultiDataSourceConfigGenerator {
    * @param hibernateBeanContainerPropertyFieldSpec the {@link FieldSpec} for the hibernate bean
    *                                                container property constant
    * @return the {@link MethodSpec} builder for the {@link LocalContainerEntityManagerFactoryBean}
+   * bean
    */
   private @Nonnull MethodSpec.Builder createEntityManagerFactoryBeanMethod(
       @Nonnull FieldSpec beanNameFieldSpece,

--- a/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
+++ b/src/main/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGenerator.java
@@ -17,7 +17,6 @@ import io.github.dhi13man.spring.datasource.utils.MultiDataSourceGeneratorUtils;
 import java.util.Properties;
 import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -238,9 +237,10 @@ public class MultiDataSourceConfigGenerator {
    *                                          the data source are located (to be included in the
    *                                          {@link EnableJpaRepositories} annotation)
    * @param entityManagerFactoryBeanNameField the {@link FieldSpec} for the
-   *                                          {@link EntityManagerFactory} bean name constant. This
-   *                                          is used to reference the {@link EntityManagerFactory}
-   *                                          bean in the {@link EnableJpaRepositories} annotation
+   *                                          {@link LocalContainerEntityManagerFactoryBean} bean
+   *                                          name constant. This is used to reference the
+   *                                          {@link LocalContainerEntityManagerFactoryBean} bean in
+   *                                          the {@link EnableJpaRepositories} annotation
    * @param transactionManagerBeanNameField   the {@link FieldSpec} for the
    *                                          {@link PlatformTransactionManager} bean name constant.
    *                                          This is used to reference the
@@ -431,10 +431,12 @@ public class MultiDataSourceConfigGenerator {
   }
 
   /**
-   * Create the {@link MethodSpec} builder for the {@link EntityManagerFactory} bean.
+   * Create the {@link MethodSpec} builder for the {@link LocalContainerEntityManagerFactoryBean}
+   * bean.
    * <p>
-   * {@link EntityManagerFactory} will determine the {@link javax.persistence.EntityManager}
-   * implementation to use based on the {@link DataSource} implementation for complex queries.
+   * {@link LocalContainerEntityManagerFactoryBean} will determine the
+   * {@link javax.persistence.EntityManager} implementation to use based on the {@link DataSource}
+   * implementation for complex queries.
    *
    * @param beanNameFieldSpece                      the {@link FieldSpec} for this bean name
    *                                                constant
@@ -446,7 +448,7 @@ public class MultiDataSourceConfigGenerator {
    *                                                dependency bean name constant
    * @param hibernateBeanContainerPropertyFieldSpec the {@link FieldSpec} for the hibernate bean
    *                                                container property constant
-   * @return the {@link MethodSpec} builder for the {@link EntityManagerFactory} bean
+   * @return the {@link MethodSpec} builder for the {@link LocalContainerEntityManagerFactoryBean}
    */
   private @Nonnull MethodSpec.Builder createEntityManagerFactoryBeanMethod(
       @Nonnull FieldSpec beanNameFieldSpece,
@@ -514,7 +516,8 @@ public class MultiDataSourceConfigGenerator {
    *
    * @param beanNamefieldSpec                     the {@link FieldSpec} for this bean name constant
    * @param entityManagerFactoryBeanNameFieldSpec the {@link FieldSpec} for the
-   *                                              {@link EntityManagerFactory} dependency bean
+   *                                              {@link LocalContainerEntityManagerFactoryBean}
+   *                                              dependency bean
    * @return the {@link MethodSpec} builder for the {@link PlatformTransactionManager} bean
    */
   private @Nonnull MethodSpec.Builder createTransactionManagerBeanMethod(
@@ -533,7 +536,7 @@ public class MultiDataSourceConfigGenerator {
 
     // Create the method parameters (EntityManagerFactory dependency)
     final ParameterSpec entityManagerFactoryParameter = ParameterSpec
-        .builder(EntityManagerFactory.class, "entityManagerFactory")
+        .builder(LocalContainerEntityManagerFactoryBean.class, "entityManagerFactoryBean")
         .addAnnotation(qualifierAnnotation)
         .build();
 
@@ -545,7 +548,7 @@ public class MultiDataSourceConfigGenerator {
         .returns(PlatformTransactionManager.class)
         .addParameter(entityManagerFactoryParameter)
         .addStatement(
-            "return new $T($N)",
+            "return new $T($N.getObject())",
             JpaTransactionManager.class,
             entityManagerFactoryParameter
         );

--- a/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
+++ b/src/test/java/io/github/dhi13man/spring/datasource/generators/MultiDataSourceConfigGeneratorTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -103,8 +102,10 @@ class MultiDataSourceConfigGeneratorTest {
   void generateMultiDataSourceConfigTypeElementGetTransactionManager() {
     for (final IMultiDataSourceConfig generatedConfig : generatedConfigs) {
       // Arrange
-      final EntityManagerFactory mockEntityManagerFactory = Mockito
-          .mock(EntityManagerFactory.class);
+      final LocalContainerEntityManagerFactoryBean mockEntityManagerFactory = Mockito
+          .mock(LocalContainerEntityManagerFactoryBean.class);
+      Mockito.when(mockEntityManagerFactory.getObject())
+          .thenReturn(Mockito.mock());
 
       // Act
       final PlatformTransactionManager transactionManager = generatedConfig


### PR DESCRIPTION
- [Added support for Java 17+ by abstracting away all usages of `javax.persistence` from the generated code](https://github.com/Dhi13man/spring-multi-data-source/commit/59571322dbdd49a056751d0cb51201834b738d2c)
- [Removed `javax.persistence` from Docs as well](https://github.com/Dhi13man/spring-multi-data-source/commit/71c3dccbf04bda5b7310a87954e4b400a4440ca8)